### PR TITLE
[CTAKES-531] change String.replaceAll() to replace() to improve performance

### DIFF
--- a/ctakes-core/src/main/java/org/apache/ctakes/core/cc/html/HtmlTextWriter.java
+++ b/ctakes-core/src/main/java/org/apache/ctakes/core/cc/html/HtmlTextWriter.java
@@ -813,11 +813,11 @@ final public class HtmlTextWriter extends AbstractJCasFileWriter {
       if ( text.isEmpty() ) {
          return "";
       }
-      String safeText = text.replaceAll( "'", "&apos;" );
-      safeText = safeText.replaceAll( "\"", "&quot;" );
-      safeText = safeText.replaceAll( "@", "&amp;" );
-      safeText = safeText.replaceAll( "<", "&lt;" );
-      safeText = safeText.replaceAll( ">", "&gt;" );
+      String safeText = text.replace( "'", "&apos;" );
+      safeText = safeText.replace( "\"", "&quot;" );
+      safeText = safeText.replace( "@", "&amp;" );
+      safeText = safeText.replace( "<", "&lt;" );
+      safeText = safeText.replace( ">", "&gt;" );
       return safeText;
    }
 

--- a/ctakes-gui/src/main/java/org/apache/ctakes/gui/dictionary/util/FileUtil.java
+++ b/ctakes-gui/src/main/java/org/apache/ctakes/gui/dictionary/util/FileUtil.java
@@ -24,7 +24,7 @@ final public class FileUtil {
       if ( dirPath == null || dirPath.isEmpty() ) {
          return parseDirText( "." );
       } else if ( dirPath.startsWith( "~" ) ) {
-         return parseDirText( dirPath.replaceAll( "~", System.getProperty( "user.home" ) ) );
+         return parseDirText( dirPath.replace( "~", System.getProperty( "user.home" ) ) );
       } else if ( dirPath.equals( "." ) ) {
          final String userDir = System.getProperty( "user.dir" );
          if ( userDir == null || userDir.isEmpty() ) {


### PR DESCRIPTION
Fix ISSUE (#CTAKES-531-PATCH)[https://issues.apache.org/jira/browse/CTAKES-531].
Since the string to be replaced contains none special characters, there is no need to use regular expression that in turn has bad influence to the performance.