### PR TITLE
Update ctakes-ytex to support MySQLversion 8.0.x database

### DIFF
--- a/ctakes-ytex/scripts/data/build.xml
+++ b/ctakes-ytex/scripts/data/build.xml
@@ -531,7 +531,8 @@ ${sql.delimiter}
 		<copy file="${basedir}/conn.xml.template" tofile="${java.io.tmpdir}/conn.xml" overwrite="yes">
 			<filterset>
 				<filter token="db.driver" value="${db.driver}" />
-				<filter token="db.url" value="${db.url}" />
+                <!-- conn.xml needs to replace with ampersands escaped -->
+				<filter token="db.url" value="${xmldb.url}" />
 				<filter token="db.username" value="${db.username}" />
 				<filter token="db.password" value="${db.password}" />
 			</filterset>

--- a/ctakes-ytex/scripts/data/mysql/kernel/create_tables.sql
+++ b/ctakes-ytex/scripts/data/mysql/kernel/create_tables.sql
@@ -159,17 +159,20 @@ create table feature_eval (
   index ix_feature_eval(corpus_name, cv_fold_id, type)
 ) engine=myisam comment 'evaluation of a set of features in a corpus';
 
-create table feature_rank (
-  feature_rank_id int auto_increment not null primary key,
-  feature_eval_id int not null comment 'fk feature_eval',
-  feature_name varchar(50) not null comment 'name of feature',
-  evaluation double not null default 0 comment 'measurement of feature worth',
-  rank int not null default 0 comment 'rank among all features',
-  unique index nk_feature_name(feature_eval_id, feature_name),
-  index ix_feature_rank(feature_eval_id, rank),
-  index ix_feature_evaluation(feature_eval_id, evaluation),
-  index fk_feature_eval(feature_eval_id)
-) engine=myisam comment 'evaluation of a feature in a corpus';
+-- update for MySQL 8.0.x
+CREATE TABLE `feature_rank` (
+  `feature_rank_id` int NOT NULL AUTO_INCREMENT,
+  `feature_eval_id` int NOT NULL COMMENT 'fk feature_eval',
+  `feature_name` varchar(50) NOT NULL COMMENT 'name of feature',
+  `evaluation` double NOT NULL DEFAULT '0' COMMENT 'measurement of feature worth',
+  `rank` int NOT NULL DEFAULT '0' COMMENT 'rank among all features',
+  PRIMARY KEY (`feature_rank_id`),
+  UNIQUE KEY `nk_feature_name` (`feature_eval_id`,`feature_name`),
+  INDEX `ix_feature_rank` (`feature_eval_id`,`rank`),
+  INDEX `ix_feature_evaluation` (`feature_eval_id`,`evaluation`),
+  INDEX `fk_feature_eval` (`feature_eval_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COMMENT='evaluation of a feature in a corpus';
+
 
 CREATE TABLE feature_parchd (
   feature_parchd_id int(11) NOT NULL AUTO_INCREMENT,
@@ -211,18 +214,23 @@ create table hotspot_instance (
     unique index NK_hotspot_instance (corpus_name, experiment, label, instance_id)
 ) engine=myisam comment 'hotspot features for an instance';
 
-create table hotspot_sentence (
-    hotspot_sentence_id int auto_increment not null primary key,
-    hotspot_instance_id int not null comment 'fk hotspot_instance',
-    anno_base_id int not null comment 'fk anno_sentence',
-    evaluation double not null default 0 comment 'max eval from hotspot',
-    rank int not null default 0 comment 'min rank from hotspot',
-    unique index NK_hotspot_sentence (hotspot_instance_id, anno_base_id),
-    index FK_hotspot_instance_id (hotspot_instance_id),
-	index FK_anno_base_id (anno_base_id),
-    INDEX IX_evaluation (hotspot_instance_id, evaluation),
-    INDEX IX_rank (hotspot_instance_id, rank)
-) engine = myisam comment 'sentences that contain hotspots at specified threshold';
+
+-- update for MySQL 8.0.x
+CREATE TABLE `hotspot_sentence` (
+  `hotspot_sentence_id` int NOT NULL AUTO_INCREMENT,
+  `hotspot_instance_id` int NOT NULL COMMENT 'fk hotspot_instance',
+  `anno_base_id` int NOT NULL COMMENT 'fk anno_sentence',
+  `evaluation` double NOT NULL DEFAULT '0' COMMENT 'max eval from hotspot',
+  `rank` int NOT NULL DEFAULT '0' COMMENT 'min rank from hotspot',
+  PRIMARY KEY (`hotspot_sentence_id`),
+  UNIQUE KEY `NK_hotspot_sentence` (`hotspot_instance_id`,`anno_base_id`),
+  INDEX `FK_hotspot_instance_id` (`hotspot_instance_id`),
+  INDEX `FK_anno_base_id` (`anno_base_id`),
+  INDEX `IX_evaluation` (`hotspot_instance_id`,`evaluation`),
+  INDEX `IX_rank` (`hotspot_instance_id`,`rank`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COMMENT='sentences that contain hotspots at specified threshold';
+
+
 
 create table corpus_doc (
 	corpus_name varchar(50) not null comment 'corpus name',

--- a/ctakes-ytex/src/main/resources/org/apache/ctakes/ytex/conceptGraph/sct-msh-csp-aod.template.xml
+++ b/ctakes-ytex/src/main/resources/org/apache/ctakes/ytex/conceptGraph/sct-msh-csp-aod.template.xml
@@ -24,7 +24,7 @@
         <entry key="ytex.conceptGraphQuery"><![CDATA[
         select distinct cui1, cui2 
         from @umls.schema@.MRREL 
-        where sab in ('SNOMEDCT', 'MSH' , 'CSP', 'AOD')
+        where sab in ('SNOMEDCT_US', 'MSH' , 'CSP', 'AOD')
         and rel in ('PAR', 'RB')
         order by cui1, cui2
         ]]></entry>

--- a/ctakes-ytex/src/main/resources/org/apache/ctakes/ytex/conceptGraph/sct-rxnorm.template.xml
+++ b/ctakes-ytex/src/main/resources/org/apache/ctakes/ytex/conceptGraph/sct-rxnorm.template.xml
@@ -24,7 +24,7 @@
         <entry key="ytex.conceptGraphQuery"><![CDATA[
         select distinct cui1, cui2 
         from @umls.schema@.MRREL 
-        where sab in ('SNOMEDCT', 'RXNORM')
+        where sab in ('SNOMEDCT_US', 'RXNORM')
         and rel in ('PAR', 'RB')
         order by cui1, cui2
         ]]></entry>

--- a/ctakes-ytex/src/main/resources/org/apache/ctakes/ytex/conceptGraph/sct-umls.template.xml
+++ b/ctakes-ytex/src/main/resources/org/apache/ctakes/ytex/conceptGraph/sct-umls.template.xml
@@ -24,7 +24,7 @@
         <entry key="ytex.conceptGraphQuery"><![CDATA[
         select distinct cui1, cui2 
         from @umls.schema@.MRREL 
-        where sab in ('SNOMEDCT')
+        where sab in ('SNOMEDCT_US')
         and rel in ('PAR')
         order by cui1, cui2
         ]]></entry>

--- a/ctakes-ytex/src/main/resources/org/apache/ctakes/ytex/ytex.properties.mssql.example
+++ b/ctakes-ytex/src/main/resources/org/apache/ctakes/ytex/ytex.properties.mssql.example
@@ -8,6 +8,10 @@ db.schema=dbo
 # with the values of db.host and db.name respectively
 db.url=jdbc:sqlserver://localhost;databaseName=YTEX;integratedSecurity=true
 
+# The xmldb.url should be a duplicate of db.url with the exception of replacing an & with &amp;
+# This is a stopgap to allow conn.xml.template to not break in the SAX parser
+xmldb.url=jdbc:sqlserver://localhost;databaseName=YTEX;integratedSecurity=true
+
 # assume windows integrated authentication, change if necessary
 db.username=
 db.password=

--- a/ctakes-ytex/src/main/resources/org/apache/ctakes/ytex/ytex.properties.mysql.example
+++ b/ctakes-ytex/src/main/resources/org/apache/ctakes/ytex/ytex.properties.mysql.example
@@ -6,7 +6,12 @@ db.username=ytex
 db.password=ytex
 
 # jdbc url for database.  schema name must match db.schema
-db.url=jdbc:mysql://localhost:3306/ytex?autoReconnect=true
+db.url=jdbc:mysql://localhost:3306/ytex?autoReconnect=TRUE&serverTimezone=US/Eastern&useUnicode=true&characterEncoding=utf8&useSSL=false&allowPublicKeyRetrieval=true
+
+# The xmldb.url should be a duplicate of db.url with the exception of replacing an & with &amp;
+# This is a stopgap to allow conn.xml.template to not break in the SAX parser
+xmldb.url=jdbc:mysql://localhost:3306/ytex?autoReconnect=TRUE&amp;serverTimezone=US/Eastern&amp;useUnicode=true&amp;characterEncoding=utf8&amp;useSSL=false&amp;allowPublicKeyRetrieval=true
+
 
 # the schema where umls is installed
 # if not specified, will default to schema from ytex

--- a/ctakes-ytex/src/main/resources/org/apache/ctakes/ytex/ytex.properties.orcl.example
+++ b/ctakes-ytex/src/main/resources/org/apache/ctakes/ytex/ytex.properties.orcl.example
@@ -3,6 +3,10 @@
 # another format that works is e.g.: jdbc:oracle:thin:ytex/ytex@localhost:1521:orcl
 db.url=jdbc:oracle:thin:@localhost:1521:orcl
 
+# The xmldb.url should be a duplicate of db.url with the exception of replacing an & with &amp;
+# This is a stopgap to allow conn.xml.template to not break in the SAX parser
+xmldb.url=jdbc:oracle:thin:@localhost:1521:orcl
+
 # oracle username and password
 # user needs connect, resource, and create view privileges
 db.username=ytex_test

--- a/ctakes-ytex/src/test/resources/org/apache/ctakes/ytex/ytex.hsql.properties.template
+++ b/ctakes-ytex/src/test/resources/org/apache/ctakes/ytex/ytex.hsql.properties.template
@@ -8,6 +8,7 @@ db.password=
 db.directory=@ytex.hsql.db@
 # jdbc url for database.  schema name must match db.schema
 db.url=jdbc:hsqldb:file://@ytex.hsql.db@;shutdown=true
+xmldb.url=jdbc:hsqldb:file://@ytex.hsql.db@;shutdown=true
 
 # the schema where umls is installed
 # if not specified, will default to schema from ytex

--- a/ctakes-ytex/src/test/resources/org/apache/ctakes/ytex/ytex.hsqldb.properties
+++ b/ctakes-ytex/src/test/resources/org/apache/ctakes/ytex/ytex.hsqldb.properties
@@ -26,6 +26,7 @@ db.schema=ytex
 # jdbc url for database.  Replace localhost and YTEX_TEST 
 # with the values of db.host and db.name respectively
 db.url=jdbc:hsqldb:hsql://localhost;databaseName=YTEX_TEST;integratedSecurity=false
+xmldb.url=jdbc:hsqldb:hsql://localhost;databaseName=YTEX_TEST;integratedSecurity=false
 
 # assume windows integrated authentication, change if necessary
 db.username=ytex_test

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
 		<maven-surefire-plugin.version>3.2.3</maven-surefire-plugin.version>
 		<maven-failsafe-plugin.version>3.2.3</maven-failsafe-plugin.version>
 		<maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
-		<mysql-connector.version>5.1.26</mysql-connector.version>
+		<mysql-connector.version>8.0.33</mysql-connector.version>
 		<scala-library.version>2.11.7</scala-library.version>
 		<scala-tools.version>0.4.0</scala-tools.version>
 		<servlet-jsp-api.version>2.2</servlet-jsp-api.version>


### PR DESCRIPTION
This pull requests makes the following changes:

- Update the ctakes parent pom.xml to bump support to MySQL 8.0.33
- Update the concept graph templates to reference SNOMEDCT as SNOMEDCT_US which is the current name in UMLS
- Update the create_tables.sql to be compatible with MySQL 8.0.x SQL commands
- Update the ytex.properties examples to reflect that we need an xmldb.url to specify when JDBC URLs containing an ampersand which must be escaped by the SAX parser when processing templates for conn.xml in the ant build process.

Further notes for testing:

Once this patch is applied, you can generate new concept graphs using a locally installed version of the UMLS database following the previous directions from the ctakes website.  Running the command "ant -f build-setup.xml all" will create the ytex database using a new version of the UMLS, but you should update the scripts/data/umls/MRCONSO.RRF and MRSTY.RRF with your current extract. These files are too large now to commit to github.  If you are going to build multiple sources into a single concept graph, insure that all sources are represented in the MRCONSO.RRF file for the umls_aui_fword generation steps which setup the ytex database prior to creating concept graphs.

The concept graph sct-rxnorm database by default as specified in the buildnon-asf.xml file. If you want to generate an alternate concept network, update the cg.name to match one of the templates provided (e.g. sct-umls will build ONLY the Snomed concept graph - you can specify any number of sources as long as they exist in your local UMLS database). See the main method in  o.a.ctakes.ytex.kernal.dao.ConceptDaoImpl.java for examples on how to generate a new concept graph from code.