### PR TITLE
ctakes-ytex kernel similarity metrics cleanup and bug fix

### DIFF
--- a/ctakes-ytex/src/main/java/org/apache/ctakes/ytex/kernel/metric/IntrinsicLCHMetric.java
+++ b/ctakes-ytex/src/main/java/org/apache/ctakes/ytex/kernel/metric/IntrinsicLCHMetric.java
@@ -26,31 +26,43 @@ import java.util.Map;
  * 
  * Scale to unit interval
  * 
+ * Correction to the algorithm as noted in:
+ * https://bmcbioinformatics.biomedcentral.com/articles/10.1186/1471-2105-13-261
+ * 
  * @author vijay
  * 
  */
 public class IntrinsicLCHMetric extends BaseSimilarityMetric {
-	double logMaxIC2 = 0d;
-
-	public IntrinsicLCHMetric(ConceptSimilarityService simSvc, Double maxIC) {
-		super(simSvc);
-		if (maxIC != null)
-			this.logMaxIC2 = Math.log(2 * maxIC.doubleValue()) + 1d;
-	}
+	
+	double maxIC2 = 0d;
 
 	@Override
 	public double similarity(String concept1, String concept2,
 			Map<String, Double> conceptFilter, SimilarityInfo simInfo) {
-		double sim = 0d;
-		if (logMaxIC2 != 0d) {
+		
+		if (maxIC2 != 0d) {
+			
 			double ic1 = simSvc.getIC(concept1, true);
 			double ic2 = simSvc.getIC(concept2, true);
 			double lcsIC = initLcsIC(concept1, concept2, conceptFilter,
 					simInfo, true);
-			sim = 1 - (Math.log(ic1 + ic2 - 2 * (lcsIC) + 1) / logMaxIC2);
-
+			
+			// Compute the Intrinsic LCH metric
+			return Math.log( (ic1 + ic2 - (2d * lcsIC) + 1d) / maxIC2) * -1.0d;
+			
 		}
-		return sim;
+		return 0d;		
+		
 	}
+	
+	public IntrinsicLCHMetric(ConceptSimilarityService simSvc, Double maxIC) {
+		super(simSvc);
+		if (maxIC != null) {
+			// Compute the denominator of the Intrinsic LCH metric
+			this.maxIC2 = 2.0d * maxIC.doubleValue();
+		}
+	}
+
+
 
 }

--- a/ctakes-ytex/src/main/java/org/apache/ctakes/ytex/kernel/metric/JaccardMetric.java
+++ b/ctakes-ytex/src/main/java/org/apache/ctakes/ytex/kernel/metric/JaccardMetric.java
@@ -42,7 +42,15 @@ public class JaccardMetric extends BaseSimilarityMetric {
 			return 0d;
 		double ic1 = simSvc.getIC(concept1, true);
 		double ic2 = simSvc.getIC(concept2, true);
-		return lcsIC / (ic1 + ic2 - lcsIC);
+		
+		//
+		// Test that we get a positive denominator
+		//
+		if ( ic1 + ic2 > lcsIC ) {
+			return lcsIC / (ic1 + ic2 - lcsIC);
+		} else {
+			return 0d;
+		}
 	}
 
 }

--- a/ctakes-ytex/src/main/java/org/apache/ctakes/ytex/kernel/metric/LCHMetric.java
+++ b/ctakes-ytex/src/main/java/org/apache/ctakes/ytex/kernel/metric/LCHMetric.java
@@ -20,22 +20,34 @@ package org.apache.ctakes.ytex.kernel.metric;
 
 import java.util.Map;
 
+/**
+ * 
+ * This metric is an implementation of the semantic relatedness measure described
+ * by Leacock and Chodorow (1998).
+ * 
+ * See reference paper: https://aclanthology.org/J06-1003.pdf
+ * Page 19, Sec 2.5.3 (7)
+ * 
+ * sim(c1,c2) = -log ( len(c1,c2) / 2 * max_depth )
+ * 
+ */
 public class LCHMetric extends BaseSimilarityMetric {
 	/**
-	 * log(max depth * 2)
+	 * natural log(max depth * 2)
 	 */
-	double logdm = 0d;
+	double maxDepth = 0d;
 
 	@Override
 	public double similarity(String concept1, String concept2,
 			Map<String, Double> conceptFilter, SimilarityInfo simInfo) {
-		if (logdm != 0d) {
+		if (maxDepth != 0d) {
 			initLCSes(concept1, concept2, simInfo);
 			if (simInfo.getLcsDist() > 0) {
-				// double lch = logdm - Math.log((double) simInfo.getLcsDist());
-				// // scale to depth
-				// return lch / logdm;
-				return 1 - (Math.log((double) simInfo.getLcsDist()) / logdm);
+
+				// Compute the length between the concepts
+				double lch = Math.log((double) simInfo.getLcsDist() / (double)(2 * maxDepth)) * -1.0d;
+				return lch;
+				
 			}
 		}
 		return 0d;
@@ -44,7 +56,16 @@ public class LCHMetric extends BaseSimilarityMetric {
 	public LCHMetric(ConceptSimilarityService simSvc, Integer maxDepth) {
 		super(simSvc);
 		if (maxDepth != null) {
-			this.logdm = Math.log(2 * maxDepth);
+			// Math.log is the natural log by default
+			// The cTakes concept graphs are adding an extra node which 
+			// represents C0000000 as the root node rather than the source
+			// specific root and inflating the depth, we need to reduce
+			// maxDepth by 2 to correct for this
+			if ( maxDepth > 3 ) {
+				this.maxDepth = maxDepth - 2;
+			} else {
+				this.maxDepth = maxDepth;
+			}
 		}
 	}
 

--- a/ctakes-ytex/src/main/java/org/apache/ctakes/ytex/kernel/metric/LinMetric.java
+++ b/ctakes-ytex/src/main/java/org/apache/ctakes/ytex/kernel/metric/LinMetric.java
@@ -46,30 +46,39 @@ public class LinMetric extends BaseSimilarityMetric {
 	@Override
 	public double similarity(String concept1, String concept2,
 			Map<String, Double> conceptFilter, SimilarityInfo simInfo) {
-		// don't bother if the concept graph is null
+
+		// Test that there is a valid concept graph
 		if (!validCG)
 			return 0d;
-		// get lcs
-		double lcsIC = initLcsIC(concept1, concept2, conceptFilter, simInfo,
-				this.intrinsicIC);
-		if (lcsIC == 0d) {
-			return 0d;
-		}
-		// get ic of concepts
+		
+		// Compute the IC values for each concept
 		double ic1 = simSvc.getIC(concept1, this.intrinsicIC);
 		double ic2 = simSvc.getIC(concept2, this.intrinsicIC);
+		
+		// Get the LCS with the lowest IC score
+		double lcsIC = initLcsIC(concept1, concept2, conceptFilter, simInfo,
+				this.intrinsicIC);
+		
 		// if the corpus IC is 0 and the concept is not the root, then we don't
 		// have any IC on the concept and can't measure similarity - return 0
 		if (!intrinsicIC && ic1 == 0 && !rootConcept.equals(concept1))
 			return 0d;
+
 		if (!intrinsicIC && ic2 == 0 && !rootConcept.equals(concept2))
 			return 0d;
-		double denom = ic1 + ic2;
-		if (denom == 0)
-			return 0d;
-		return 2 * lcsIC / denom;
+		
+		// Compute the Lin score
+		double sim = (2d * lcsIC) / ( ic1 + ic2 );
+		return sim;	
+		
 	}
 
+	/**
+	 * This constructor allows us to specify if we want the standard Lin
+	 * metric or the Intrinsic Lin by passing a boolean flag
+	 * @param simSvc
+	 * @param intrinsicIC if true, then compute the intrinsic Lin metric
+	 */
 	public LinMetric(ConceptSimilarityService simSvc, boolean intrinsicIC) {
 		super(simSvc);
 		this.intrinsicIC = intrinsicIC;

--- a/ctakes-ytex/src/main/java/org/apache/ctakes/ytex/kernel/metric/SokalSneathMetric.java
+++ b/ctakes-ytex/src/main/java/org/apache/ctakes/ytex/kernel/metric/SokalSneathMetric.java
@@ -43,7 +43,7 @@ public class SokalSneathMetric extends BaseSimilarityMetric {
 			return 0d;
 		double ic1 = simSvc.getIC(concept1, true);
 		double ic2 = simSvc.getIC(concept2, true);
-		return lcsIC / (2 * (ic1 + ic2) - 3 * lcsIC);
+		return lcsIC / (2*(ic1 + ic2) - (3*lcsIC));
 	}
 
 }


### PR DESCRIPTION
This patch makes the following code cleanup and mathematical corrections to the kernel metrics:

- IntrinsicLCHMetric contained a mathematical error where the formula misinterpreted that it should be -1 times the log and instead had an implementation that was 1 minus the log. In addition, the way the concept graph is computed, there is a dummy root node created which inflated the depth of the nodes by (2) - this is now corrected and the output matches exactly to values computed by the Perl UMLS::Similarity LCH computation
- LCHMetric contained a mathematical error where the formula misinterpreted that it should be -1 times the log and instead had an implementation that was 1 minus the log. The LCH metric also contained the same depth error as LCH intrinsic and this has been corrected.
- JaccardMetric could have had a divide by zero if the ic1 + ic2 was equal to the lcsIC. Added a check to insure this does not happen.
- The LinMetric code has been cleaned up to be more readable
- SokalMetric - added a parenthesis for clarity that the formula is evaluated properly
- Wu-Palmer Metric also suffered from a mis-calculation of node depth due to the dummy node.  This code was also cleaned up to be more readable and to document exactly how the similarity score is computed.
