### PR TITLE
ctakes-ytex adding Resnik and Faith algorithms

### DIFF
--- a/ctakes-ytex/src/main/java/org/apache/ctakes/ytex/kernel/metric/ConceptSimilarityService.java
+++ b/ctakes-ytex/src/main/java/org/apache/ctakes/ytex/kernel/metric/ConceptSimilarityService.java
@@ -32,7 +32,9 @@ public interface ConceptSimilarityService {
 		LCH(false, false), INTRINSIC_LCH(true, false), LIN(false, true), INTRINSIC_LIN(
 				true, false), PATH(false, false), INTRINSIC_PATH(true, false), JACCARD(
 				true, false), SOKAL(true, false), RADA(false, false), INTRINSIC_RADA(
-				true, false), WUPALMER(false, false), PAGERANK(false, false);
+				true, false), WUPALMER(false, false), PAGERANK(false, false), 
+				RESNIK(false, false), INTRINSIC_RESNIK(true, false),
+				FAITH(false, false), INTRINSIC_FAITH(true, false);
 		boolean intrinsicIC = false;
 		boolean corpusIC = false;
 

--- a/ctakes-ytex/src/main/java/org/apache/ctakes/ytex/kernel/metric/ConceptSimilarityServiceImpl.java
+++ b/ctakes-ytex/src/main/java/org/apache/ctakes/ytex/kernel/metric/ConceptSimilarityServiceImpl.java
@@ -856,6 +856,15 @@ public class ConceptSimilarityServiceImpl implements ConceptSimilarityService {
 					new JaccardMetric(this));
 			this.similarityMetricMap.put(SimilarityMetricEnum.WUPALMER,
 					new WuPalmerMetric(this));
+			this.similarityMetricMap.put(SimilarityMetricEnum.INTRINSIC_RESNIK,
+					new ResnikMetric(this, true));
+			this.similarityMetricMap.put(SimilarityMetricEnum.RESNIK,
+					new ResnikMetric(this, false));
+			this.similarityMetricMap.put(SimilarityMetricEnum.INTRINSIC_FAITH,
+					new FaithMetric(this, true));
+			this.similarityMetricMap.put(SimilarityMetricEnum.FAITH,
+					new FaithMetric(this, false));
+			
 		} else {
 			this.similarityMetricMap.put(SimilarityMetricEnum.PAGERANK,
 					new PageRankMetric(this, this.getPageRankService()));

--- a/ctakes-ytex/src/main/java/org/apache/ctakes/ytex/kernel/metric/FaithMetric.java
+++ b/ctakes-ytex/src/main/java/org/apache/ctakes/ytex/kernel/metric/FaithMetric.java
@@ -1,0 +1,96 @@
+package org.apache.ctakes.ytex.kernel.metric;
+
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * compute Faith score to provide functionality as found in UMLS::Similarity
+ * 
+ * UMLS::Similarity::faith.pm
+ * Module implementing the semantic relatedness measure described 
+ * by Pirro and Euzenat (2010)
+ * 
+ * Described in:
+ * https://inria.hal.science/hal-00793283/file/pirro2010b.pdf
+ * 
+ * @author painter
+ * 
+ */
+public class FaithMetric extends BaseSimilarityMetric {
+
+	private static final Log log = LogFactory.getLog(LinMetric.class);
+	private boolean intrinsicIC = true;
+	private boolean validCG = false;
+	private String rootConcept = simSvc.getConceptGraph().getRoot();
+
+	public boolean isIntrinsicIC() {
+		return intrinsicIC;
+	}
+
+	public void setIntrinsicIC(boolean intrinsicIC) {
+		this.intrinsicIC = intrinsicIC;
+	}
+
+	@Override
+	public double similarity(String concept1, String concept2,
+			Map<String, Double> conceptFilter, SimilarityInfo simInfo) {
+		// don't bother if the concept graph is null
+		if (!validCG)
+			return 0d;
+		
+		// Compute the IC values for each concept
+		double ic1 = simSvc.getIC(concept1, this.intrinsicIC);
+		double ic2 = simSvc.getIC(concept2, this.intrinsicIC);
+		
+		// Get the LCS with the lowest IC score
+		double lcsIC = initLcsIC(concept1, concept2, conceptFilter, simInfo,
+				this.intrinsicIC);
+		
+		// if the corpus IC is 0 and the concept is not the root, then we don't
+		// have any IC on the concept and can't measure similarity - return 0
+		if (!intrinsicIC && ic1 == 0 && !rootConcept.equals(concept1))
+			return 0d;
+
+		if (!intrinsicIC && ic2 == 0 && !rootConcept.equals(concept2))
+			return 0d;
+		
+		// Compute the faith score
+		if ( ic1 > 0 && ic2 > 0 ) {
+			double sim = (lcsIC) / ( ic1 + ic2 - lcsIC );
+			return sim;	
+		} else {
+			return 0d;
+		}
+	}
+
+	public FaithMetric(ConceptSimilarityService simSvc, boolean intrinsicIC) {
+		super(simSvc);
+		this.intrinsicIC = intrinsicIC;
+		this.validCG = simSvc.getConceptGraph() != null;
+		if (!this.intrinsicIC && validCG) {
+			rootConcept = simSvc.getConceptGraph().getRoot();
+		}
+	}
+
+}

--- a/ctakes-ytex/src/main/java/org/apache/ctakes/ytex/kernel/metric/ResnikMetric.java
+++ b/ctakes-ytex/src/main/java/org/apache/ctakes/ytex/kernel/metric/ResnikMetric.java
@@ -1,0 +1,86 @@
+package org.apache.ctakes.ytex.kernel.metric;
+
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * compute Resnik score to provide functionality as found in UMLS::Similarity
+ * 
+ * UMLS::Similarity::res.pm
+ * Module implementing the semantic relatedness measure described 
+ * by Resnik (1995)
+ * 
+ * @author painter
+ * 
+ */
+public class ResnikMetric extends BaseSimilarityMetric {
+	private static final Log log = LogFactory.getLog(LinMetric.class);
+	private boolean intrinsicIC = true;
+	private boolean validCG = false;
+	private String rootConcept = simSvc.getConceptGraph().getRoot();
+
+	public boolean isIntrinsicIC() {
+		return intrinsicIC;
+	}
+
+	public void setIntrinsicIC(boolean intrinsicIC) {
+		this.intrinsicIC = intrinsicIC;
+	}
+
+	@Override
+	public double similarity(String concept1, String concept2,
+			Map<String, Double> conceptFilter, SimilarityInfo simInfo) {
+		// don't bother if the concept graph is null
+		if (!validCG)
+			return 0d;
+		
+		// get the minimum lcs of the two concepts
+		double lcsIC = initLcsIC(concept1, concept2, conceptFilter, simInfo,
+				this.intrinsicIC);
+		
+		// Test for zero
+		if (lcsIC == 0d) {
+			return 0d;
+		}
+		
+		//
+		// Resnik simply returns the minimum IC score of the LCSes
+		//
+		// Note: When comparing results to the Perl UMLS::Similarity metric from CPAN
+		//       you would need to specify the "--intrinsic sanchez" method
+		//       to find comparable IC as cTakes is only computing IC in this way
+		//
+		return lcsIC;
+	}
+
+	public ResnikMetric(ConceptSimilarityService simSvc, boolean intrinsicIC) {
+		super(simSvc);
+		this.intrinsicIC = intrinsicIC;
+		this.validCG = simSvc.getConceptGraph() != null;
+		if (!this.intrinsicIC && validCG) {
+			rootConcept = simSvc.getConceptGraph().getRoot();
+		}
+	}
+
+}


### PR DESCRIPTION
This patch includes code to add 2 additional metrics to the ctakes-ytex framework which replicate the similarity metrics found in the Perl UMLS::Similarity package for Resnik (both intrinsic and without) as well as the Faith algorithms.  The new metrics are registered in the ConceptSimilarityService such that they can be called exactly as the other metrics.

Examples were computed and compared with output from the Perl UMLS::Similarity and verified to be the same.  However, this requires that when testing against Perl's package, you must specify to use --instrinsic sanchez as the cTakes YTEX implementation of the IC is ONLY using the Sanchez implementation.  If you do not specify the Resnik when calling the perl scripts, it will default to the corpus based IC which results in different numbers being produced.  Once you force it to use the Sanchez IC, the distance metrics correspond exactly when running against the same UMLS database installed.