### PR TITLE
Ctakes ytex conceptgraph

### DIFF
--- a/ctakes-ytex/src/main/java/org/apache/ctakes/ytex/kernel/IntrinsicInfoContentEvaluatorImpl.java
+++ b/ctakes-ytex/src/main/java/org/apache/ctakes/ytex/kernel/IntrinsicInfoContentEvaluatorImpl.java
@@ -460,8 +460,16 @@ public class IntrinsicInfoContentEvaluatorImpl implements
 				}
 			}
 		}
-		if (calcDepth)
-			depthArray[concept.getNodeIndex()] = (short) (parentMaxDepth + 1);
+		
+		// Compute the current depth of the concept node
+		if (calcDepth) {
+			// Dummy concept has no length
+			if ( concept.getConceptID().contentEquals("C0000000") ) { 
+				depthArray[concept.getNodeIndex()] = (short) (0);
+			} else {
+				depthArray[concept.getNodeIndex()] = (short) (parentMaxDepth + 1);
+			}
+		}
 		// add the concept itself to the set of subsumers
 		subsumers.add(concept.getConceptID());
 		// add this to the cache - copy the key so that this can be gc'ed as

--- a/ctakes-ytex/src/main/java/org/apache/ctakes/ytex/kernel/metric/IntrinsicLCHMetric.java
+++ b/ctakes-ytex/src/main/java/org/apache/ctakes/ytex/kernel/metric/IntrinsicLCHMetric.java
@@ -24,33 +24,43 @@ import java.util.Map;
  * compute intrinsic LCH as in eqn 28 from
  * http://dx.doi.org/10.1016/j.jbi.2011.03.013
  * 
- * Scale to unit interval
+ * This version is NOT scaled to the unit metric
  * 
  * @author vijay
  * 
  */
 public class IntrinsicLCHMetric extends BaseSimilarityMetric {
-	double logMaxIC2 = 0d;
-
-	public IntrinsicLCHMetric(ConceptSimilarityService simSvc, Double maxIC) {
-		super(simSvc);
-		if (maxIC != null)
-			this.logMaxIC2 = Math.log(2 * maxIC.doubleValue()) + 1d;
-	}
+	
+	double maxIC2 = 0d;
 
 	@Override
 	public double similarity(String concept1, String concept2,
 			Map<String, Double> conceptFilter, SimilarityInfo simInfo) {
-		double sim = 0d;
-		if (logMaxIC2 != 0d) {
+		
+		if (maxIC2 != 0d) {
+			
 			double ic1 = simSvc.getIC(concept1, true);
 			double ic2 = simSvc.getIC(concept2, true);
 			double lcsIC = initLcsIC(concept1, concept2, conceptFilter,
 					simInfo, true);
-			sim = 1 - (Math.log(ic1 + ic2 - 2 * (lcsIC) + 1) / logMaxIC2);
-
+			
+			// Compute the Intrinsic LCH metric
+			double sim = Math.log( (ic1 + ic2 - (2d * lcsIC) + 1d) / maxIC2) * -1.0d;
+			return sim;
+			
 		}
-		return sim;
+		return 0d;		
+		
 	}
+	
+	public IntrinsicLCHMetric(ConceptSimilarityService simSvc, Double maxIC) {
+		super(simSvc);
+		if (maxIC != null) {
+			// Compute the denominator of the Intrinsic LCH metric
+			this.maxIC2 = 2.0d * maxIC.doubleValue();
+		}
+	}
+
+
 
 }

--- a/ctakes-ytex/src/main/java/org/apache/ctakes/ytex/kernel/metric/JaccardMetric.java
+++ b/ctakes-ytex/src/main/java/org/apache/ctakes/ytex/kernel/metric/JaccardMetric.java
@@ -42,7 +42,15 @@ public class JaccardMetric extends BaseSimilarityMetric {
 			return 0d;
 		double ic1 = simSvc.getIC(concept1, true);
 		double ic2 = simSvc.getIC(concept2, true);
-		return lcsIC / (ic1 + ic2 - lcsIC);
+		
+		//
+		// Test that we get a positive denominator
+		//
+		if ( ic1 + ic2 > lcsIC ) {
+			return lcsIC / (ic1 + ic2 - lcsIC);
+		} else {
+			return 0d;
+		}
 	}
 
 }

--- a/ctakes-ytex/src/main/java/org/apache/ctakes/ytex/kernel/metric/LinMetric.java
+++ b/ctakes-ytex/src/main/java/org/apache/ctakes/ytex/kernel/metric/LinMetric.java
@@ -46,30 +46,39 @@ public class LinMetric extends BaseSimilarityMetric {
 	@Override
 	public double similarity(String concept1, String concept2,
 			Map<String, Double> conceptFilter, SimilarityInfo simInfo) {
-		// don't bother if the concept graph is null
+
+		// Test that there is a valid concept graph
 		if (!validCG)
 			return 0d;
-		// get lcs
-		double lcsIC = initLcsIC(concept1, concept2, conceptFilter, simInfo,
-				this.intrinsicIC);
-		if (lcsIC == 0d) {
-			return 0d;
-		}
-		// get ic of concepts
+		
+		// Compute the IC values for each concept
 		double ic1 = simSvc.getIC(concept1, this.intrinsicIC);
 		double ic2 = simSvc.getIC(concept2, this.intrinsicIC);
+		
+		// Get the LCS with the lowest IC score
+		double lcsIC = initLcsIC(concept1, concept2, conceptFilter, simInfo,
+				this.intrinsicIC);
+		
 		// if the corpus IC is 0 and the concept is not the root, then we don't
 		// have any IC on the concept and can't measure similarity - return 0
 		if (!intrinsicIC && ic1 == 0 && !rootConcept.equals(concept1))
 			return 0d;
+
 		if (!intrinsicIC && ic2 == 0 && !rootConcept.equals(concept2))
 			return 0d;
-		double denom = ic1 + ic2;
-		if (denom == 0)
-			return 0d;
-		return 2 * lcsIC / denom;
+		
+		// Compute the Lin score
+		double sim = (2d * lcsIC) / ( ic1 + ic2 );
+		return sim;	
+		
 	}
 
+	/**
+	 * This constructor allows us to specify if we want the standard Lin
+	 * metric or the Intrinsic Lin by passing a boolean flag
+	 * @param simSvc
+	 * @param intrinsicIC if true, then compute the intrinsic Lin metric
+	 */
 	public LinMetric(ConceptSimilarityService simSvc, boolean intrinsicIC) {
 		super(simSvc);
 		this.intrinsicIC = intrinsicIC;

--- a/ctakes-ytex/src/main/java/org/apache/ctakes/ytex/kernel/metric/WuPalmerMetric.java
+++ b/ctakes-ytex/src/main/java/org/apache/ctakes/ytex/kernel/metric/WuPalmerMetric.java
@@ -20,20 +20,41 @@ package org.apache.ctakes.ytex.kernel.metric;
 
 import java.util.Map;
 
+/**
+ * Wu-Palmer metric matches results as found in the CPAN UMLS-Similarity::wup module
+ * 
+ * @author vijay
+ * @author painter
+ * 
+ */
 public class WuPalmerMetric extends BaseSimilarityMetric {
 	@Override
 	public double similarity(String concept1, String concept2,
 			Map<String, Double> conceptFilter, SimilarityInfo simInfo) {
 		initLCSes(concept1, concept2, simInfo);
+		
 		if (simInfo.getLcses().size() > 0) {
 			int lcsDepth = 0;
+			
+			// Test for the LCS with the greatest depth
+			// to find the lowest common synonym
 			for (String lcs : simInfo.getLcses()) {
-				int d = simSvc.getDepth(lcs);
+				
+				// The depth of the LCS is off by 1
+				int d = simSvc.getDepth(lcs) + 1;
+				// Find the max depth of the LCS
 				if (d > lcsDepth)
 					lcsDepth = d;
 			}
-			double lcsDepth2 = (double) (lcsDepth * 2);
-			return lcsDepth2 / (lcsDepth2 + (double) (simInfo.getLcsDist()-1));
+			
+			//
+			// Compute Wu-Palmer Similarity:
+			//
+			double lcsDist = simInfo.getLcsDist().doubleValue();
+			double c1Depth = simSvc.getDepth(concept1) + lcsDist;
+			double c2Depth = simSvc.getDepth(concept2) + lcsDist ;
+			double score = ( 2.0 * (lcsDepth) / ( c1Depth + c2Depth ) );
+			return score;
 		}
 		return 0d;
 	}


### PR DESCRIPTION
This patch makes the following code cleanup and mathematical corrections to the kernel metrics as well as the max-depth calculation for a concept graph:

Correct the construction of the initial concept graph whereby the dummy root node has a depth value of zero which was creating wildly unreasonable max-depths for individual graphs.

IntrinsicLCHMetric contained a mathematical error where the formula misinterpreted that it should be -1 times the log and instead had an implementation that was 1 minus the log. In addition, the way the concept graph is computed, there is a dummy root node created which inflated the depth of the nodes by (2) - this is now corrected and the output matches exactly to values computed by the Perl UMLS::Similarity LCH computation

LCHMetric contained a mathematical error where the formula misinterpreted that it should be -1 times the log and instead had an implementation that was 1 minus the log. The LCH metric also contained the same depth error as LCH intrinsic and this has been corrected.

JaccardMetric could have had a divide by zero if the ic1 + ic2 was equal to the lcsIC. Added a check to insure this does not happen.

The LinMetric code has been cleaned up to be more readable

Wu-Palmer Metric also suffered from a mis-calculation of node depth due to the dummy node. This code was also cleaned up to be more readable and to more accurately reflect the computations in the Perl UMLS::Similarity wup.pm module.