### PR TITLE
Disabling the LCS caching as it provides inconsistent results

### DIFF
--- a/ctakes-ytex/src/main/java/org/apache/ctakes/ytex/kernel/metric/ConceptSimilarityServiceImpl.java
+++ b/ctakes-ytex/src/main/java/org/apache/ctakes/ytex/kernel/metric/ConceptSimilarityServiceImpl.java
@@ -50,6 +50,14 @@ import java.util.*;
  * 
  */
 public class ConceptSimilarityServiceImpl implements ConceptSimilarityService {
+
+    // The original implementation included code to cache LCS's to save 
+    // computation time. However, this resulted in distance metrics that
+    // were inconsistent when calling subsequent CUI pairs. To ensure 
+    // replicable results across calls to the similarity service, the 
+    // caching mechanism should be disabled for now.
+    private static boolean ENABLE_LCS_CACHING = false;
+
 	private static final Log log = LogFactory
 			.getLog(ConceptSimilarityServiceImpl.class);
 
@@ -630,7 +638,9 @@ public class ConceptSimilarityServiceImpl implements ConceptSimilarityService {
 						.getConceptID() : cr1.getConceptID());
 		String cacheKey = cacheKeyBuilder.toString();
 		Element e = this.lcsCache != null ? this.lcsCache.get(cacheKey) : null;
-		if (e != null) {
+		
+		// If the LCS cache is disabled, we will fall through
+		if (e != null && ENABLE_LCS_CACHING == true) {
 			// hit the cache - unpack the lcs
 			if (e.getObjectValue() != null) {
 				Object[] val = (Object[]) e.getObjectValue();


### PR DESCRIPTION
Upon repeated analysis of distance metrics, discrepancies were observed. This appears to be caused by the YTEX package attempting to cache LCS's between CUIs, leading to inconsistent outputs when making repeated calls to the similarity service. By disabling the cache, each distance computation is forced to locate the LCS, ensuring consistent output even when calling multiple CUI pairs in succession.

From my testing, the performance impact of disabling the cache is negligible. Until further investigation can determine why the cache is causing inconsistencies, it is advisable to keep it disabled.